### PR TITLE
let's myQRCode display faction QR codes based on dropdown in top bar

### DIFF
--- a/components/myQRCode.tsx
+++ b/components/myQRCode.tsx
@@ -13,12 +13,11 @@ export default function MyQRCode(props:MyQRCodeProps):JSX.Element {
   const { 
     state,
   }: NnProviderValues = useContext(NnContext); 
+  
+  const accountId = state?.network?.selected?.account || 'Meat Popsicle';
 
-  const userId:string = useMemo(() => {
-    return state?.user?.profile?.auth?.userid || 'Meat Popcicle';
-  }, [state]);
   const size = props?.size || 500;
-  const value = props?.value || userId;
+  const value = props?.value || accountId;
 
   return (
     <>


### PR DESCRIPTION
The Discover - My QR Code display would only display the personal QR code even if a faction was selected in the drop down, which means it would be very hard to, for example, send credits to the casino wallet.

This brings in the accountId from the dropdown instead of the userId before rendering the QR code.