### PR TITLE
Returns all scans  of valid ID numbers, not just users

### DIFF
--- a/components/qrCodeReader.tsx
+++ b/components/qrCodeReader.tsx
@@ -10,8 +10,9 @@ export default function QrCodeReader(props: QrCodeReaderProps): JSX.Element {
 
   const onSuccess = (result:any) => {
     console.log('result', result);
-    let cleanId = result?.replace(/[^0-9]+/g, '') || '';
-    successHandler && successHandler(cleanId);
+    if (result.match(/^[0-9a-zA-Z]{1}[0-9]{9}$/g)) {
+      successHandler && successHandler(result);
+    }
   }
 
   const onError = (error:any) => {


### PR DESCRIPTION
This function was only passing user ID numbers to the identify function (and was mistakenly running a replace that would replace alphabetic characters with numeric values which caused misreads or malformed QR codes to lead to unexpected user ID numbers). New regex compares to the actual [1 letter or number][9 numbers] and returns when it matches.