### PR TITLE
86 transaction history only shows personal wallet regardless of faction choice

### DIFF
--- a/components/cashHistoryApp.tsx
+++ b/components/cashHistoryApp.tsx
@@ -78,6 +78,7 @@ export default function CashApp(props: CashAppProps):JSX.Element {
     return filteredValue;
   }
 
+
   const [ walletFetched, setWalletFetched ] = useState(false);
   const [ transactionsFetched, setTransactionsFetched ] = useState(false);
   const wallets = useMemo(() => { return state?.user?.wallets || [{}] }, [state]);
@@ -87,19 +88,12 @@ export default function CashApp(props: CashAppProps):JSX.Element {
   const balance = wallet ? wallet?.balance : null;
   const walletId = wallet ? wallet?.id : personalWallet;
   const [ lastWalletFetched, setLastWalletFetched ] = useState(walletId);
-  const transactions = useMemo(() => {
-    if (walletId != lastWalletFetched) {
-      setLastWalletFetched(walletId);
-      setTransactionsFetched(false);
-      setWalletFetched(false);
-    }
-    setTransactionsFetched(false);
+  const transactions = useMemo(() => { 
     const transArr = state?.network?.collections?.transactions || [];
     return transArr.length > 30 ? transArr.slice(0, 30) : transArr;
-  }, [lastWalletFetched, walletId, state]);
+  }, [state]);
 
   const goFetchWallets = useCallback(() => {
-
     if (!walletFetched) {
       fetchUserWallets();
       setWalletFetched(true);
@@ -107,6 +101,7 @@ export default function CashApp(props: CashAppProps):JSX.Element {
   }, [walletFetched, fetchUserWallets])
 
   const goFetchWalletsHistory = useCallback(() => {
+    setLastWalletFetched(walletId);
     if (!transactionsFetched) {
       if (walletId?.charAt(0) != "C") {
         fetchUserWalletHistory();
@@ -125,13 +120,21 @@ export default function CashApp(props: CashAppProps):JSX.Element {
   }, [wallets, goFetchWallets]);
 
   useEffect(() => {
-    
     if (!transactions.length) {
       goFetchWalletsHistory();
     }
   }, [transactions, goFetchWalletsHistory]);
 
-  if (lastWalletFetched != walletId) { goFetchWalletsHistory() };
+  useEffect(() => {
+    if (walletId != lastWalletFetched) {
+      setLastWalletFetched(walletId);
+      goFetchWalletsHistory()
+    }
+    else {
+      setTransactionsFetched(true);
+    }
+    setTransactionsFetched(false);
+  }, [walletId, lastWalletFetched])
 
   return (
     <Container disableGutters style={{height: '100%'}}>

--- a/components/context/nnActionsCash.ts
+++ b/components/context/nnActionsCash.ts
@@ -127,3 +127,31 @@ export const fetchUserWalletHistory = (dispatch: DispatchFunc) => async () => {
     executeApi('walletHistory', {token}, onSuccess, onError); 
   }
 };
+
+export const fetchFactionWalletHistory = (dispatch: DispatchFunc) => async (faction:string) => {
+  const token = getCookieToken();
+  const onSuccess = (response:APIResponse) => {
+    const { data } = response;
+    storeFetched('userWallet', data);
+    dispatch({
+      type: 'setWalletTransactions',
+      payload: data,
+    })
+  };
+  const onError = (err:netcheckAPIResData) => {
+    const { message = 'Wallet History failure' } = err;
+    dispatch({
+      type: 'setAlert',
+      payload: {severity: 'error', message, show: true},
+    })
+  };
+  if (storedRecently('userWallet')) {
+    const data = getLocalStorage('userWallet');
+    dispatch({
+      type: 'setWalletTransactions',
+      payload: data,
+    })
+  } else {
+    executeApi('factionWalletHistory', {token, faction}, onSuccess, onError); 
+  }
+};

--- a/components/context/nnContext.tsx
+++ b/components/context/nnContext.tsx
@@ -34,6 +34,7 @@ import {
 import {
   fetchUserWallets,
   fetchUserWalletHistory,
+  fetchFactionWalletHistory,
   requestPayment,
   requestFactionPayment,
   sendPayment,
@@ -243,6 +244,7 @@ export const { Context, Provider } = DataContextCreator(
     fetchUserSetStatuses,
     fetchUserStatuses,
     fetchUserWalletHistory,
+    fetchFactionWalletHistory,
     fetchUserWallets,
     initContext,
     joinFaction,

--- a/components/context/nnTypes.ts
+++ b/components/context/nnTypes.ts
@@ -261,6 +261,7 @@ export type NnProviderDispatch = {
     setFactionUserStatus: (_factionId:string, _body:string, _userId?:string) => void;
     fetchUserSetStatuses: (_userId:string) => void;
     fetchUserWalletHistory: () => void;
+    fetchFactionWalletHistory: (_factionId:string) => void;
     initContext: () => void;
     leaveFaction: (_factionId:string) => void;
     updateFactionProfile: (_factionId:string, _document:any, _update:any) => void;

--- a/utilities/constants.ts
+++ b/utilities/constants.ts
@@ -58,7 +58,11 @@ export const authApiEnpoints = {
   },
   walletHistory: {
     method: "get",
-    path: "/api/user/walletHistory",
+    path: "/api/user/wallethistory",
+  },
+  factionWalletHistory: {
+    method: "get",
+    path: "/api/factions/$faction/wallethistory",
   },
   pay: {
     method: "put",


### PR DESCRIPTION
Adds functions to fetch faction wallet history.

On faction selection in wallet history page, checks if wallet is different from last fetch, and if it is, fetches the appropriate history