### PR TITLE
Issue 04 - add copy button to id field on security page

### DIFF
--- a/components/userSecurityApp.tsx
+++ b/components/userSecurityApp.tsx
@@ -11,6 +11,8 @@ import {
   Button,
   CircularProgress,
   Divider,
+  InputAdornment,
+  IconButton,
   Link,
   Typography,
   TextField,

--- a/components/userSecurityApp.tsx
+++ b/components/userSecurityApp.tsx
@@ -76,11 +76,7 @@ export default function UserSecurityApp(props: UserSecurityAppProps): JSX.Elemen
     }
   }, [SecurityFetched, fetchUserProfile]);
 
-  const handleMouseDownCopy = (event: React.MouseEvent<HTMLButtonElement>) => {
-    event.preventDefault();
-  };
-
-  const handleMouseUpCopy = (event: React.MouseEvent<HTMLButtonElement>) => {
+  const handleMouseUpDownIgnore = (event: React.MouseEvent<HTMLButtonElement>) => {
     event.preventDefault();
   };
   
@@ -129,8 +125,8 @@ export default function UserSecurityApp(props: UserSecurityAppProps): JSX.Elemen
                                 <IconButton 
                                   aria-label='Copy User ID'
                                   onClick={setClipboard}
-                                  onMouseDown={handleMouseDownCopy}
-                                  onMouseUp={handleMouseUpCopy}
+                                  onMouseDown={handleMouseUpDownIgnore}
+                                  onMouseUp={handleMouseUpDownIgnore}
                                   edge="end"
                                 >
                                   <ContentCopyIcon />

--- a/components/userSecurityApp.tsx
+++ b/components/userSecurityApp.tsx
@@ -14,6 +14,7 @@ import {
   Link,
   Typography,
   TextField,
+  Tooltip,
 } from '@mui/material';
 import ExitToAppIcon from '@mui/icons-material/ExitToApp';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
@@ -82,12 +83,15 @@ export default function UserSecurityApp(props: UserSecurityAppProps): JSX.Elemen
   const handleMouseUpCopy = (event: React.MouseEvent<HTMLButtonElement>) => {
     event.preventDefault();
   };
-
+  
+  const [showCopyTooltip, setShowCopyTooltip] = React.useState(false);
+  
   const setClipboard = () => {
     let userid = AuthProfile?.userid;
     if (userid) {
       navigator.clipboard.writeText(userid);
-      // pop tooltip saying id was copied
+      setShowCopyTooltip(true);
+      setTimeout(setShowCopyTooltip(false), 3000); // 3 is a magic number https://www.youtube.com/watch?v=J8lRKCw2_Pk
     }
   }
 
@@ -110,32 +114,34 @@ export default function UserSecurityApp(props: UserSecurityAppProps): JSX.Elemen
                   <Box sx={{ minWidth: '100%', minHeight: '100%' }}>
                     <Stack spacing={0} sx={{ display: 'flex' }}>
                       <Divider variant="middle" color="primary"><Typography variant="h6">Account Details</Typography></Divider>
-                      <TextField
-                        name="userid"
-                        value={AuthProfile?.userid}
-                        label="User ID"
-                        variant="outlined"
-                        style={input}
-                        onClick={setClipboard}
-                        slotProps={{
-                          input: {
-                            readOnly: true,
-                            endAdornment: (
-                              <InputAdornment position="end">
-                                <IconButton 
-                                  aria-label='Copy User ID'
-                                  onClick={handleClickCopyID}
-                                  onMouseDown={handleMouseDownCopy}
-                                  onMouseUp={handleMouseUpCopy}
-                                  edge="end"
-                                >
-                                  <ContentCopyIcon />
-                                </IconButton>
-                              </InputAdornment>
-                            ),
-                          },
-                        }}
-                      />
+                      <Tooltip title="User ID Copied!" placement="top" open={showCopyTooltip} disableFocusListener disableHoverListener disableTouchListener >
+                        <TextField
+                          name="userid"
+                          value={AuthProfile?.userid}
+                          label="User ID"
+                          variant="outlined"
+                          style={input}
+                          onClick={setClipboard}
+                          slotProps={{
+                            input: {
+                              readOnly: true,
+                              endAdornment: (
+                                <InputAdornment position="end">
+                                  <IconButton 
+                                    aria-label='Copy User ID'
+                                    onClick={handleClickCopyID}
+                                    onMouseDown={handleMouseDownCopy}
+                                    onMouseUp={handleMouseUpCopy}
+                                    edge="end"
+                                  >
+                                    <ContentCopyIcon />
+                                  </IconButton>
+                                </InputAdornment>
+                              ),
+                            },
+                          }}
+                        />
+                      </Tooltip>
                       <TextField
                         name="email"
                         value={AuthProfile?.email}

--- a/components/userSecurityApp.tsx
+++ b/components/userSecurityApp.tsx
@@ -112,7 +112,7 @@ export default function UserSecurityApp(props: UserSecurityAppProps): JSX.Elemen
                   <Box sx={{ minWidth: '100%', minHeight: '100%' }}>
                     <Stack spacing={0} sx={{ display: 'flex' }}>
                       <Divider variant="middle" color="primary"><Typography variant="h6">Account Details</Typography></Divider>
-                      <Tooltip title="User ID Copied!" placement="top" open={showCopyTooltip} disableFocusListener disableHoverListener disableTouchListener >
+                      <Tooltip title="User ID Copied to Clipboard!" placement="top" open={showCopyTooltip} disableFocusListener disableHoverListener disableTouchListener >
                         <TextField
                           name="userid"
                           value={AuthProfile?.userid}

--- a/components/userSecurityApp.tsx
+++ b/components/userSecurityApp.tsx
@@ -89,7 +89,7 @@ export default function UserSecurityApp(props: UserSecurityAppProps): JSX.Elemen
     if (userid) {
       navigator.clipboard.writeText(userid);
       setShowCopyTooltip(true);
-      setTimeout(setShowCopyTooltip(false), 3000); // 3 is a magic number https://www.youtube.com/watch?v=J8lRKCw2_Pk
+      setTimeout(() => setShowCopyTooltip(false), 3000); // 3 is a magic number https://www.youtube.com/watch?v=J8lRKCw2_Pk
     }
   }
 

--- a/components/userSecurityApp.tsx
+++ b/components/userSecurityApp.tsx
@@ -74,8 +74,6 @@ export default function UserSecurityApp(props: UserSecurityAppProps): JSX.Elemen
     }
   }, [SecurityFetched, fetchUserProfile]);
 
-  const handleClickCopyID = () => setClipboard();
-
   const handleMouseDownCopy = (event: React.MouseEvent<HTMLButtonElement>) => {
     event.preventDefault();
   };
@@ -129,7 +127,7 @@ export default function UserSecurityApp(props: UserSecurityAppProps): JSX.Elemen
                                 <InputAdornment position="end">
                                   <IconButton 
                                     aria-label='Copy User ID'
-                                    onClick={handleClickCopyID}
+                                    onClick={setClipboard}
                                     onMouseDown={handleMouseDownCopy}
                                     onMouseUp={handleMouseUpCopy}
                                     edge="end"

--- a/components/userSecurityApp.tsx
+++ b/components/userSecurityApp.tsx
@@ -16,6 +16,7 @@ import {
   TextField,
 } from '@mui/material';
 import ExitToAppIcon from '@mui/icons-material/ExitToApp';
+import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import { Stack } from '@mui/system';
 import { use100vh } from 'react-div-100vh';
 
@@ -97,9 +98,15 @@ export default function UserSecurityApp(props: UserSecurityAppProps): JSX.Elemen
                         label="User ID"
                         variant="outlined"
                         style={input}
-                        InputProps={{
-                          readOnly: true,
-                        }}
+                        slotProps={{
+                          input: {
+                            readOnly: true,
+                            endAdornment: (
+                              <InputAdornment position="end">
+                                <ContentCopyIcon />
+                              </InputAdornment>
+                            ),
+                          },
                       />
                       <TextField
                         name="email"

--- a/components/userSecurityApp.tsx
+++ b/components/userSecurityApp.tsx
@@ -73,6 +73,24 @@ export default function UserSecurityApp(props: UserSecurityAppProps): JSX.Elemen
     }
   }, [SecurityFetched, fetchUserProfile]);
 
+  const handleClickCopyID = () => setClipboard();
+
+  const handleMouseDownCopy = (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.preventDefault();
+  };
+
+  const handleMouseUpCopy = (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.preventDefault();
+  };
+
+  const setClipboard = () => {
+    let userid = AuthProfile?.userid;
+    if (userid) {
+      navigator.clipboard.writeText(userid);
+      // pop tooltip saying id was copied
+    }
+  }
+
   useEffect(() => {
     goFetchSecurity();
   }, [goFetchSecurity, AuthProfile]);
@@ -98,12 +116,21 @@ export default function UserSecurityApp(props: UserSecurityAppProps): JSX.Elemen
                         label="User ID"
                         variant="outlined"
                         style={input}
+                        onClick={setClipboard}
                         slotProps={{
                           input: {
                             readOnly: true,
                             endAdornment: (
                               <InputAdornment position="end">
-                                <ContentCopyIcon />
+                                <IconButton 
+                                  aria-label='Copy User ID'
+                                  onClick={handleClickCopyID}
+                                  onMouseDown={handleMouseDownCopy}
+                                  onMouseUp={handleMouseUpCopy}
+                                  edge="end"
+                                >
+                                  <ContentCopyIcon />
+                                </IconButton>
                               </InputAdornment>
                             ),
                           },

--- a/components/userSecurityApp.tsx
+++ b/components/userSecurityApp.tsx
@@ -107,6 +107,7 @@ export default function UserSecurityApp(props: UserSecurityAppProps): JSX.Elemen
                               </InputAdornment>
                             ),
                           },
+                        }}
                       />
                       <TextField
                         name="email"

--- a/components/userSecurityApp.tsx
+++ b/components/userSecurityApp.tsx
@@ -122,23 +122,20 @@ export default function UserSecurityApp(props: UserSecurityAppProps): JSX.Elemen
                           variant="outlined"
                           style={input}
                           onClick={setClipboard}
-                          slotProps={{
-                            input: {
-                              readOnly: true,
-                              endAdornment: (
-                                <InputAdornment position="end">
-                                  <IconButton 
-                                    aria-label='Copy User ID'
-                                    onClick={setClipboard}
-                                    onMouseDown={handleMouseDownCopy}
-                                    onMouseUp={handleMouseUpCopy}
-                                    edge="end"
-                                  >
-                                    <ContentCopyIcon />
-                                  </IconButton>
-                                </InputAdornment>
-                              ),
-                            },
+                          InputProps={{
+                            readOnly: true,
+                            endAdornment:
+                              <InputAdornment position="end">
+                                <IconButton 
+                                  aria-label='Copy User ID'
+                                  onClick={setClipboard}
+                                  onMouseDown={handleMouseDownCopy}
+                                  onMouseUp={handleMouseUpCopy}
+                                  edge="end"
+                                >
+                                  <ContentCopyIcon />
+                                </IconButton>
+                              </InputAdornment>
                           }}
                         />
                       </Tooltip>


### PR DESCRIPTION
Adds clickable "copy" button to User ID field on /security page that will copy the user ID to clipboard. Also makes clicking on the field copy ID to clipboard.
https://github.com/NeoNav-Team/neonav-client-web/issues/4