### PR TITLE
121 refactor front end for image api

### DIFF
--- a/components/contactDetailApp.tsx
+++ b/components/contactDetailApp.tsx
@@ -18,7 +18,7 @@ import LocalFloristIcon from '@mui/icons-material/LocalFlorist';
 import TocIcon from '@mui/icons-material/Toc';
 import { Stack } from '@mui/system';
 import { use100vh } from 'react-div-100vh';
-import { defaultImg } from '@/utilities/defaultImg';
+import { imageUrl } from '@/utilities/constants';
 import { CurrencyExchange } from '@mui/icons-material';
 
 
@@ -204,7 +204,7 @@ export default function ContactDetailApp(props: ContactsAppProps):JSX.Element {
                 >
                   <div style={{
                     ...sizedImage,
-                    backgroundImage: `url("${entity?.image || defaultImg}")`,
+                    backgroundImage: `url("${imageUrl(entity?.id || '')}")`,
                     backgroundSize: 'cover',
                     maxWidth:'95vw',
                   }}>

--- a/components/contactsApp.tsx
+++ b/components/contactsApp.tsx
@@ -9,6 +9,7 @@ import React, {
 import styles from '../styles/generic.module.css';
 import { Context as NnContext } from './context/nnContext';
 import { NnProviderValues, NnContact, nnEntity } from './context/nnTypes';
+import { imageUrl } from '../utilities/constants';
 import SimpleScrollContainer from './simpleScrollContainer';
 import QrCodeReader from './qrCodeReader';
 import ItemContact from './itemContact';
@@ -211,7 +212,7 @@ export default function ContactsApp(props: ContactsAppProps):JSX.Element {
                           key={`${item.id}`}
                           id={item.id || ''}
                           username={displayname}
-                          thumbnail={item.thumbnail}
+                          thumbnail={imageUrl(item.id || '', true)}
                         />
                       </div> 
                     )

--- a/components/factionProfileApp.tsx
+++ b/components/factionProfileApp.tsx
@@ -4,6 +4,9 @@ import React, { useCallback, useContext, useEffect, useMemo, useState } from 're
 import Resizer from "react-image-file-resizer";
 import styles from '../styles/generic.module.css';
 import { isJsonStringValid } from '@/utilities/json';
+import { imageUrl } from '@/utilities/constants';
+import executeAPI from '@/utilities/executeApi';
+import { getCookieToken } from '@/utilities/cookieContext';
 import { Context as NnContext } from './context/nnContext';
 import { NnProviderValues, nnEntity, NnContact, NnStatus } from './context/nnTypes';
 import SimpleScrollContainer from './simpleScrollContainer';
@@ -115,7 +118,7 @@ export default function FactionProfileApp(props: FactionProfileAppProps):JSX.Ele
   const [ profileFetched, setProfileFetched ] = useState(false);
   const [ editMode, setEditMode ] = useState(false);
   const [ form, setForm ] = useState<Form>(defaultProfile);
-  const { name, image, tagline, description } = form;
+  const { name, tagline, description } = form;
   const [ photo, setPhoto ] = useState<string | undefined>();
   const [ completeProfile, setCompleteProfile ] = useState(defaultProfile);
   const isRecentEntity = profile.id === factionId;
@@ -139,7 +142,7 @@ export default function FactionProfileApp(props: FactionProfileAppProps):JSX.Ele
 
   useEffect(() => {
     goFetchFactionProfile();
-  }, [accountId, goFetchFactionProfile, profile]);
+  }, [accountId, goFetchFactionProfile]);
 
   useEffect(() => {
     if (Object.keys(profile).length >= 3) {
@@ -167,7 +170,10 @@ export default function FactionProfileApp(props: FactionProfileAppProps):JSX.Ele
       0,
       (uri) => {
         setForm({...form, [field]:uri } );
-        setPhoto(uri as string);
+        if (field === 'image') {
+          setPhoto(uri as string);
+          executeAPI('updateFactionImage', { faction: factionId, image: uri, token: getCookieToken() }, null, null);
+        }
       },
       "base64"
     );
@@ -189,14 +195,16 @@ export default function FactionProfileApp(props: FactionProfileAppProps):JSX.Ele
       _id: state?.network?.entity?._id,
       _rev: state?.network?.entity?._rev,
     }
+    setProfileFetched(false);
     updateFactionProfile(accountId, doc, form);
-  } 
+  }
 
   const editButtonAction = ()=> {
     if (editMode) {
       saveProfileChanges();
-      setPhoto(image);
+      setPhoto(undefined);
     } else {
+      setProfileFetched(false);
       goFetchFactionProfile(); //get latest before editing
     }
     setEditMode(!editMode);
@@ -228,7 +236,7 @@ export default function FactionProfileApp(props: FactionProfileAppProps):JSX.Ele
                         >
                           {editMode ? (
                             <Stack spacing={2} >
-                              <img src={photo || image} alt="Please upload an image" style={{minWidth: 200, minHeight: 200, maxWidth: '95%', maxHeight: 400}} />
+                              <img src={photo || imageUrl(factionId)} alt="Please upload an image" style={{minWidth: 200, minHeight: 200, maxWidth: '95%', maxHeight: 400}} />
                               <Button variant="contained" component="label" endIcon={<PhotoCameraIcon />}>
                                 Upload
                                 <input hidden multiple type="file" onChange={uploadHandler} accept="image/png, image/jpeg" />
@@ -239,7 +247,7 @@ export default function FactionProfileApp(props: FactionProfileAppProps):JSX.Ele
                             </Stack>
                           ) : (
                             <>
-                              <SubheaderFaction title={completeProfile.name} subtitle={completeProfile.tagline} photo={completeProfile.image}/>
+                              <SubheaderFaction title={completeProfile.name} subtitle={completeProfile.tagline} photo={imageUrl(factionId)}/>
                             </>
                           )}
                         </Box>

--- a/components/factionProfileApp.tsx
+++ b/components/factionProfileApp.tsx
@@ -40,22 +40,13 @@ interface FactionProfileAppProps {
 
 type Form = {
   name?: string;
-  image?: string;
   tagline?: string;
   description?: string;
 }
-type FormKey = 
-  'name' | 
-  'image' | 
-  'tagline' | 
-  'description';
-
 const defaultProfile = {
   id: '',
   name: '',
   tagline: '',
-  image: '',
-  thumbnail: '',
   description: '',
   admin: [],
   members: [],
@@ -160,7 +151,7 @@ export default function FactionProfileApp(props: FactionProfileAppProps):JSX.Ele
     }
   }, [isRecentEntity, profile]);
 
-  const resizeFile = (file:File, field:FormKey, size:number) => {
+  const resizeFile = (file:File, size:number) => {
     Resizer.imageFileResizer(
       file,
       size,
@@ -169,11 +160,8 @@ export default function FactionProfileApp(props: FactionProfileAppProps):JSX.Ele
       100,
       0,
       (uri) => {
-        setForm({...form, [field]:uri } );
-        if (field === 'image') {
-          setPhoto(uri as string);
-          executeAPI('updateFactionImage', { faction: factionId, image: uri, token: getCookieToken() }, null, null);
-        }
+        setPhoto(uri as string);
+        executeAPI('updateFactionImage', { faction: factionId, image: uri, token: getCookieToken() }, null, null);
       },
       "base64"
     );
@@ -186,7 +174,7 @@ export default function FactionProfileApp(props: FactionProfileAppProps):JSX.Ele
 
   const uploadHandler = async (event:React.ChangeEvent<HTMLInputElement>) => {
     const { files } = event?.currentTarget;
-    files && resizeFile(files[0], 'image', 600);
+    files && resizeFile(files[0], 600);
   }
 
 

--- a/components/factionProfileApp.tsx
+++ b/components/factionProfileApp.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @next/next/no-img-element */
 'use client';
-import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import Resizer from "react-image-file-resizer";
 import styles from '../styles/generic.module.css';
 import { isJsonStringValid } from '@/utilities/json';
@@ -115,7 +115,7 @@ export default function FactionProfileApp(props: FactionProfileAppProps):JSX.Ele
   const reps = profile && profile?.reps;
   const isAdmin = profile && userId === admin?.userid;
   const isRep = isAdmin || (reps && reps.filter((user:NnContact) => user.id === userId).length >= 1);
-  const [ profileFetched, setProfileFetched ] = useState(false);
+  const fetchedRef = useRef(false);
   const [ editMode, setEditMode ] = useState(false);
   const [ form, setForm ] = useState<Form>(defaultProfile);
   const { name, tagline, description } = form;
@@ -124,11 +124,9 @@ export default function FactionProfileApp(props: FactionProfileAppProps):JSX.Ele
   const isRecentEntity = profile.id === factionId;
 
   const goFetchFactionProfile = useCallback(() => {
-    if (!profileFetched) {
-      fetchFactionDetails(accountId);
-      fetchFactionStatuses(accountId);
-    }
-  }, [profileFetched, fetchFactionDetails, accountId, fetchFactionStatuses]);
+    fetchFactionDetails(accountId);
+    fetchFactionStatuses(accountId);
+  }, [fetchFactionDetails, accountId, fetchFactionStatuses]);
 
   const updateDefaultForm = (profile:nnEntity) => {
     let updatedDefaultForm:Form = JSON.parse(JSON.stringify(defaultProfile));
@@ -141,7 +139,10 @@ export default function FactionProfileApp(props: FactionProfileAppProps):JSX.Ele
   }
 
   useEffect(() => {
-    goFetchFactionProfile();
+    if (!fetchedRef.current) {
+      fetchedRef.current = true;
+      goFetchFactionProfile();
+    }
   }, [accountId, goFetchFactionProfile]);
 
   useEffect(() => {
@@ -156,7 +157,6 @@ export default function FactionProfileApp(props: FactionProfileAppProps):JSX.Ele
       const clonedDefaultForm:Form = JSON.parse(JSON.stringify(defaultProfile));
       const completeProfile =  {...clonedDefaultForm, ...clonedProfile};
       setCompleteProfile(completeProfile);
-      setProfileFetched(true);
     }
   }, [isRecentEntity, profile]);
 
@@ -195,7 +195,6 @@ export default function FactionProfileApp(props: FactionProfileAppProps):JSX.Ele
       _id: state?.network?.entity?._id,
       _rev: state?.network?.entity?._rev,
     }
-    setProfileFetched(false);
     updateFactionProfile(accountId, doc, form);
   }
 
@@ -204,7 +203,6 @@ export default function FactionProfileApp(props: FactionProfileAppProps):JSX.Ele
       saveProfileChanges();
       setPhoto(undefined);
     } else {
-      setProfileFetched(false);
       goFetchFactionProfile(); //get latest before editing
     }
     setEditMode(!editMode);
@@ -223,7 +221,7 @@ export default function FactionProfileApp(props: FactionProfileAppProps):JSX.Ele
       >
         <Box sx={{...flexContainer, minHeight: FLEX_HEIGHT, maxHeight: FLEX_HEIGHT}}>
           <Box sx={{...flexBody, maxHeight: SCROLL_HEIGHT }}>
-            {(profileFetched && isRecentEntity) ? (
+            {isRecentEntity ? (
               profile && Object.keys(profile).length !== 0 ?(
                 <SimpleScrollContainer>
                   <Box sx={{minWidth: '100%', minHeight: '100%'}}>

--- a/components/factionsAllApp.tsx
+++ b/components/factionsAllApp.tsx
@@ -4,6 +4,7 @@ import { usePathname } from 'next/navigation'
 import styles from '../styles/generic.module.css';
 import { Context as NnContext } from './context/nnContext';
 import { NnProviderValues, NnFaction, NnSimpleEntity } from './context/nnTypes';
+import { imageUrl } from '../utilities/constants';
 import SimpleScrollContainer from './simpleScrollContainer';
 import ItemContact from './itemContact';
 import FooterNav from './footerNav';
@@ -129,7 +130,7 @@ export default function FactionsAllApp(props: FactionsAllAppProps):JSX.Element {
                             key={`${item.id}`}
                             id={item.id || ''}
                             username={item.name}
-                            thumbnail={(item as NnFaction).thumbnail}
+                            thumbnail={imageUrl(item.id || '', true)}
                             collection="factions"
                           />
                         </div>

--- a/components/factionsApp.tsx
+++ b/components/factionsApp.tsx
@@ -3,6 +3,7 @@ import React, { useCallback, useContext, useEffect, useMemo, useState } from 're
 import styles from '../styles/generic.module.css';
 import { Context as NnContext } from './context/nnContext';
 import { NnProviderValues, NnFaction, NnSimpleEntity } from './context/nnTypes';
+import { imageUrl } from '../utilities/constants';
 import SimpleScrollContainer from './simpleScrollContainer';
 import ItemContact from './itemContact';
 import FooterNav from './footerNav';
@@ -107,7 +108,7 @@ export default function FactionsApp(props: FactionsAppProps):JSX.Element {
                             key={`${item.id}`}
                             id={item.id || ''}
                             username={item.name}
-                            thumbnail={item.thumbnail}
+                            thumbnail={imageUrl(item.id || '', true)}
                             collection="factions/admin"
                           />
                         </div> 
@@ -127,7 +128,7 @@ export default function FactionsApp(props: FactionsAppProps):JSX.Element {
                             key={`${item.id}`}
                             id={item.id || ''}
                             username={item.name}
-                            thumbnail={item.thumbnail}
+                            thumbnail={imageUrl(item.id || '', true)}
                             collection="factions/admin"
                           />
                         </div> 

--- a/components/gardenApp.tsx
+++ b/components/gardenApp.tsx
@@ -11,6 +11,7 @@ import { Context as NnContext } from "./context/nnContext";
 import { NnProviderValues, NnStatus, nnEntity } from "./context/nnTypes";
 import SimpleScrollContainer from "./simpleScrollContainer";
 import { isJsonStringValid } from "@/utilities/json";
+import { imageUrl } from "@/utilities/constants";
 import SubheaderGarden from "./subheaderEntity";
 import ItemStatus from "./itemStatus";
 import FooterNav from "./footerNav";
@@ -142,7 +143,7 @@ export default function GardenApp(props: GardenAppProps): JSX.Element {
           }}
         >
           <SubheaderGarden
-            photo={entity.image}
+            photo={imageUrl(entity.id || '')}
             title={entity.name}
             id={entity.id}
           />

--- a/components/userProfileApp.tsx
+++ b/components/userProfileApp.tsx
@@ -151,7 +151,7 @@ export default function UserProfileApp(props: UserProfileAppProps):JSX.Element {
         setForm({...form, [field]:uri } );
         if (field === 'avatar') {
           setPhoto(uri as string);
-          executeAPI('updateImage', { id: userId, image: uri, token: getCookieToken() }, null, null);
+          executeAPI('updateImage', { image: uri, token: getCookieToken() }, null, null);
         }
       },
       "base64"

--- a/components/userProfileApp.tsx
+++ b/components/userProfileApp.tsx
@@ -5,6 +5,9 @@ import Resizer from "react-image-file-resizer";
 import styles from '../styles/generic.module.css';
 import { Context as NnContext } from './context/nnContext';
 import { NnProviderValues, nnEntity } from './context/nnTypes';
+import { imageUrl } from '../utilities/constants';
+import executeAPI from '../utilities/executeApi';
+import { getCookieToken } from '../utilities/cookieContext';
 import SimpleScrollContainer from './simpleScrollContainer';
 import FooterNav from './footerNav';
 import { 
@@ -97,11 +100,12 @@ export default function UserProfileApp(props: UserProfileAppProps):JSX.Element {
     return state?.network?.entity?.profile || {};
   }, [state]);
   const accountId = state?.network?.selected?.account || '';
+  const userId = state?.user?.profile?.auth?.userid || '';
   const isAdmin = accountId === profile.id;
   const [ profileFetched, setProfileFetched ] = useState(false);
   const [ editMode, setEditMode ] = useState(false);
   const [ form, setForm ] = useState<Form>(defaultForm);
-  const { avatar, username, firstname, lastname, skills, occupation, bio } = form;
+  const { username, firstname, lastname, skills, occupation, bio } = form;
   const [ photo, setPhoto ] = useState<string | undefined>();
 
   const goFetchProfile = useCallback(() => {
@@ -121,7 +125,7 @@ export default function UserProfileApp(props: UserProfileAppProps):JSX.Element {
 
   useEffect(() => {
     goFetchProfile();
-  }, [goFetchProfile, profile]);
+  }, [goFetchProfile]);
 
   useEffect(() => {
     if (profileFetched && Object.keys(profile).length === 0) {
@@ -144,9 +148,11 @@ export default function UserProfileApp(props: UserProfileAppProps):JSX.Element {
       100,
       0,
       (uri) => {
-        console.log('field', field);
         setForm({...form, [field]:uri } );
-        field !== 'thumbnail' && setPhoto(uri as string);
+        if (field === 'avatar') {
+          setPhoto(uri as string);
+          executeAPI('updateImage', { id: userId, image: uri, token: getCookieToken() }, null, null);
+        }
       },
       "base64"
     );
@@ -160,7 +166,6 @@ export default function UserProfileApp(props: UserProfileAppProps):JSX.Element {
   const uploadHandler = async (event:React.ChangeEvent<HTMLInputElement>) => {
     const { files } = event?.currentTarget;
     files && resizeFile(files[0], 'avatar', 600);
-    files && setPhoto(avatar as string);
   }
 
   const saveProfileChanges = () => {
@@ -174,7 +179,7 @@ export default function UserProfileApp(props: UserProfileAppProps):JSX.Element {
   const bigButtonAction = ()=> {
     if (editMode) {
       saveProfileChanges();
-      setPhoto(avatar);
+      setPhoto(undefined);
       patchUserToken();
     } else {
       goFetchProfile(); //get latest before editing
@@ -205,7 +210,7 @@ export default function UserProfileApp(props: UserProfileAppProps):JSX.Element {
                         >
                           {editMode ? (
                             <Stack spacing={1} >
-                              <img src={photo || avatar} alt="Please upload an image" style={{minWidth: 200, minHeight: 200, maxWidth: '95%', maxHeight: 400}} />
+                              <img src={photo || imageUrl(userId)} alt="Please upload an image" style={{minWidth: 200, minHeight: 200, maxWidth: '95%', maxHeight: 400}} />
                               <Button variant="contained" component="label" endIcon={<PhotoCameraIcon />}>
                                 Upload
                                 <input hidden multiple type="file" onChange={uploadHandler} accept="image/png, image/jpeg" />
@@ -213,7 +218,7 @@ export default function UserProfileApp(props: UserProfileAppProps):JSX.Element {
                             </Stack>
                           ) : (
                             <>
-                              <Avatar src={avatar} alt="its you in the future" style={{width: 200, minHeight: 200}} />
+                              <Avatar src={imageUrl(userId)} alt="its you in the future" style={{width: 200, minHeight: 200}} />
                             </>
                           )}
                         </Box>

--- a/components/userProfileApp.tsx
+++ b/components/userProfileApp.tsx
@@ -29,8 +29,6 @@ import { use100vh } from 'react-div-100vh';
 interface UserProfileAppProps {};
 
 type Form = {
-  avatar?: string;
-  thumbnail?: string;
   username?: string;
   firstname?: string;
   lastname?: string;
@@ -38,19 +36,7 @@ type Form = {
   occupation?: string;
   bio?: string;
 }
-type FormKey = 
-'avatar' | 
-'thumbnail' | 
-'username' | 
-'firstname' | 
-'lastname' | 
-'skills' | 
-'occupation' | 
-'bio';
-
 const defaultForm = {
-  avatar: '',
-  thumbnail: '',
   username: '',
   firstname: '',
   lastname: '',
@@ -139,7 +125,7 @@ export default function UserProfileApp(props: UserProfileAppProps):JSX.Element {
     }
   }, [profile]);
 
-  const resizeFile = (file:File, field:FormKey, size:number) => {
+  const resizeFile = (file:File, size:number) => {
     Resizer.imageFileResizer(
       file,
       size,
@@ -148,11 +134,8 @@ export default function UserProfileApp(props: UserProfileAppProps):JSX.Element {
       100,
       0,
       (uri) => {
-        setForm({...form, [field]:uri } );
-        if (field === 'avatar') {
-          setPhoto(uri as string);
-          executeAPI('updateImage', { image: uri, token: getCookieToken() }, null, null);
-        }
+        setPhoto(uri as string);
+        executeAPI('updateImage', { image: uri, token: getCookieToken() }, null, null);
       },
       "base64"
     );
@@ -165,7 +148,7 @@ export default function UserProfileApp(props: UserProfileAppProps):JSX.Element {
 
   const uploadHandler = async (event:React.ChangeEvent<HTMLInputElement>) => {
     const { files } = event?.currentTarget;
-    files && resizeFile(files[0], 'avatar', 600);
+    files && resizeFile(files[0], 600);
   }
 
   const saveProfileChanges = () => {
@@ -179,7 +162,6 @@ export default function UserProfileApp(props: UserProfileAppProps):JSX.Element {
   const bigButtonAction = ()=> {
     if (editMode) {
       saveProfileChanges();
-      setPhoto(undefined);
       patchUserToken();
     } else {
       goFetchProfile(); //get latest before editing

--- a/utilities/constants.ts
+++ b/utilities/constants.ts
@@ -11,6 +11,9 @@ export const apiUrl = {
   port: "",
 };
 
+export const imageUrl = (userId: string, thumbnail = false) =>
+  `${apiUrl.protocol}://${apiUrl.hostname}/api/image/${userId}${thumbnail ? '/thumbnail' : ''}`;
+
 export const authApiEnpoints = {
   login: {
     method: "post",
@@ -219,5 +222,13 @@ export const authApiEnpoints = {
   searchUsers: {
     method: "post",
     path: "/api/user/search",
+  },
+  updateImage: {
+    method: "put",
+    path: "/api/image/$id",
+  },
+  updateFactionImage: {
+    method: "put",
+    path: "/api/image/faction/$faction",
   },
 };

--- a/utilities/constants.ts
+++ b/utilities/constants.ts
@@ -225,7 +225,7 @@ export const authApiEnpoints = {
   },
   updateImage: {
     method: "put",
-    path: "/api/image/$id",
+    path: "/api/image",
   },
   updateFactionImage: {
     method: "put",


### PR DESCRIPTION
OK, previously all faction and user images were stored inside their user documents. This was fine, conceptually, but led to us using calls to read profiles more sparingly because they were heavy.

Now images can be accessed directly on read without an access token via api.neonav.net/api/image/:userid, and the thumbnails from the same but with /thumbnail at the end.

Updating images is now handled by a put to /api/image or to /api/image/faction/:faction for factions. I've updated the profile update pages for users and factions to just update the new image directly on upload instead of waiting for a save. I know this is... not as safe for oopsies, but also it's much lower impact on everything, so.