### PR TITLE
132 - UI button tool tips

### DIFF
--- a/components/buttonHexFab.tsx
+++ b/components/buttonHexFab.tsx
@@ -4,6 +4,7 @@ import {
   Fab,
   Link,
   CircularProgress,
+  Tooltip,
 } from '@mui/material';
 import styles from '../styles/buttonHexFab.module.css';
 import SimpleDialog from './simpleDialog';
@@ -24,6 +25,7 @@ export interface ButtonHexFabProps {
     size?: BtnSizes;
     dialog?: string;
     useInput?: boolean;
+    tooltipText?: string;
 }
 
 const small = {height: '50px', width: '50px'};
@@ -65,17 +67,72 @@ export default function ButtonHexFab(props:ButtonHexFabProps):JSX.Element {
 
   const HexButton = () => { return (
     <>
-      <Fab color="secondary"
-        aria-label="scan"
-        style={{ opacity: icon && !disabled ? 1 : 0.3 }}
-        sx={getsize(size)}
-        disabled={disabled || icon ? false : true}
-        onClick={() => clickHandler()}
+      <Tooltip 
+        className={styles.footerItem}
+        title={props.tooltipText || ""} 
+        enterTouchDelay={500} // Triggers long-press slightly faster on mobile
+        leaveTouchDelay={1500} // Keeps it visible briefly after letting go
+        slotProps={{ // Styling is here becuase they don't always inherit the local CSS automatically
+          tooltip: {
+            sx: {
+              fontFamily: "'Jura', sans-serif",
+              fontSize: "1rem",
+              backgroundColor: "rgba(20, 0, 40, 0.9)", // Dark purple base
+              color: "#00f3ff", // Cyber cyan text
+              border: "1px solid #ff00ff", // Neon pink border
+              boxShadow: "0 0 10px #ff00ff, inset 0 0 5px #00f3ff",
+              padding: "8px 12px",
+
+              // The Glitch Logic
+              animation: 'heavyGlitch 3s step-end 1',
+              '@keyframes heavyGlitch': {
+                '0%, 90%, 100%': {
+                  transform: 'none',
+                  filter: 'none',
+                  textShadow: 'none',
+                  boxShadow: '0 0 10px #ff00ff, inset 0 0 5px #00f3ff',
+                  color: '#00f3ff',
+                  opacity: 1,
+                },
+                '92%': {
+                  transform: 'skewX(-15deg) scaleY(1.1)',
+                  clipPath: 'inset(10% 0 40% 0)', // Slices off the bottom
+                  filter: 'hue-rotate(90deg) brightness(2)',
+                  boxShadow: '5px 0 20px #ff00ff',
+                },
+                '94%': {
+                  transform: 'skewX(15deg) translateX(-5px)',
+                  clipPath: 'inset(50% 0 10% 0)', // Slices off the top
+                  filter: 'invert(1)',
+                  color: '#ff00ff',
+                },
+                '96%': {
+                  transform: 'none',
+                  clipPath: 'none',
+                  textShadow: '3px 0 #ff00ff, -3px 0 #00f3ff', // RGB Split
+                },
+                '98%': {
+                  transform: 'scale(1.05) rotate(1deg)',
+                  filter: 'blur(1px)',
+                  opacity: 0.7,
+                }
+              }
+            },
+          },
+        }}
       >
-        {loading ? <CircularProgress/> : (
-          icon ? clonedIconWithProps : null
-        )}
-      </Fab>
+        <Fab color="secondary"
+          aria-label="scan"
+          style={{ opacity: icon && !disabled ? 1 : 0.3 }}
+          sx={getsize(size)}
+          disabled={disabled || icon ? false : true}
+          onClick={() => clickHandler()}
+        >
+          {loading ? <CircularProgress/> : (
+            icon ? clonedIconWithProps : null
+          )}
+        </Fab>
+      </Tooltip>
       <SimpleDialog handleAction={dialogCloseAction} handleClose={handleClose} open={open} useInput={useInput} dialog={dialog} />
     </>
   )};

--- a/components/cashApp.tsx
+++ b/components/cashApp.tsx
@@ -394,21 +394,25 @@ export default function CashApp(props: CashAppProps):JSX.Element {
                 dialog: 'User ID',
                 useInput: true,
                 disabled: loading,
+                tooltipText: "Add User By ID",
               }}
               secondHexProps={{
                 icon: <QrCodeScannerIcon />,
                 handleAction: handleModelOpen,
                 disabled: loading,
+                tooltipText: "Scan QR Code",
               }}
               bigHexProps={{
                 icon: <CurrencyExchangeIcon />,
                 handleAction: handleSubmit,
                 loading: loading,
                 disabled: loading || openModel,
+                tooltipText: processTypeValue === "pay" ? "Send c±sн" : "Request c±sн", // TODO: fix this when refactoring payload form object
               }}
               thirdHexProps={{
                 icon: <QueryStatsIcon />,
                 link: `/cash/history/${accountId}`,
+                tooltipText: "Previous Transactions",
               }}
             />
           </Box>

--- a/components/cashHistoryApp.tsx
+++ b/components/cashHistoryApp.tsx
@@ -180,6 +180,7 @@ export default function CashApp(props: CashAppProps):JSX.Element {
               thirdHexProps={{
                 icon: <CurrencyExchangeIcon />,
                 link: "/cash",
+                tooltipText: "c±sн Wallet"
               }}
             />
           </Box>

--- a/components/channelAdminApp.tsx
+++ b/components/channelAdminApp.tsx
@@ -304,16 +304,19 @@ export default function ChannelAdminApp(props: ChannelAdminAppProps):JSX.Element
                 disabled: !isAdmin,
                 dialog: dialogForAction(requestValue),
                 handleAction: handleBigAction,
+                tooltipText: requests.find(req => req.value === requestValue)?.label + " User",
               }}
               thirdHexProps={{
                 icon: <NoMeetingRoomIcon />,
                 handleAction: goLeaveChannel,
-                dialog: "Leave this channel?"
+                dialog: "Leave this channel?",
+                tooltipText: "Leave Channel",
               }}
               fourthHexProps={{
                 icon: scope == 'group' ? <LockOpenIcon /> : <LockIcon />,
                 disabled: !isAdmin,
                 handleAction: goSetChannelScope,
+                tooltipText: scope == 'group' ? "Make Channel Public" : "Make Channel Private",
               }}
             />
           </Box>

--- a/components/channelsApp.tsx
+++ b/components/channelsApp.tsx
@@ -182,6 +182,7 @@ export default function ChannelsApp(props: ChannelsAppProps):JSX.Element {
                 handleAction: goCreateNewChannel,
                 dialog: 'New channel name',
                 useInput: true,
+                tooltipText: "Create Channel",
               }}
             />
           </Box>

--- a/components/contactDetailApp.tsx
+++ b/components/contactDetailApp.tsx
@@ -245,6 +245,7 @@ export default function ContactDetailApp(props: ContactsAppProps):JSX.Element {
                 {
                   icon: <PersonRemoveIcon />,
                   handleAction: goUnfriend,
+                  tooltipText: "Unfriend",
                 }
                 :
                 {
@@ -254,6 +255,7 @@ export default function ContactDetailApp(props: ContactsAppProps):JSX.Element {
               secondHexProps={{
                 icon: <CurrencyExchange />,
                 link: `/cash/${entityId}`,
+                tooltipText: "Pay or Request c±sн",
               }}
               bigHexProps={isFriend ? 
                 {
@@ -263,14 +265,17 @@ export default function ContactDetailApp(props: ContactsAppProps):JSX.Element {
                 {
                   icon: <PersonAddIcon />,
                   handleAction: goBefriend,
+                  tooltipText: "Add Friend",
                 }}
               thirdHexProps={{
                 icon: <LocalFloristIcon />,
                 link: `/garden/${entityId}`,
+                tooltipText: "Jaden/Garden",
               }}
               fourthHexProps={{
                 icon: <TocIcon />,
                 link: '/contacts',
+                tooltipText: "Contacts",
               }}
             />
           </Box>

--- a/components/contactsApp.tsx
+++ b/components/contactsApp.tsx
@@ -241,11 +241,13 @@ export default function ContactsApp(props: ContactsAppProps):JSX.Element {
                 dialog: 'User ID',
                 useInput: true,
                 disabled: loading,
+                tooltipText: "Search By ID",
               }}
               secondHexProps={{
                 icon: <QrCodeScannerIcon />,
                 handleAction: handleModelOpen,
                 disabled: loading,
+                tooltipText: "Scan QR Code",
               }}
             />
           </Box>

--- a/components/factionAdminApp.tsx
+++ b/components/factionAdminApp.tsx
@@ -332,7 +332,8 @@ export default function FactionAdminApp(props: FactionAdminAppProps):JSX.Element
               firstHexProps={{
                 icon: <NoMeetingRoomIcon />,
                 handleAction: goLeaveFaction,
-                dialog: "Leave this faction?"
+                dialog: "Leave this faction?",
+                tooltipText: "Leave Faction",
               }}
               secondHexProps={{
                 disabled: true,
@@ -341,6 +342,7 @@ export default function FactionAdminApp(props: FactionAdminAppProps):JSX.Element
                 icon: <ManageAccountsIcon />,
                 disabled: !isAdmin,
                 handleAction: handleBigAction,
+                tooltipText: "Manage Faction",
               }}
               thirdHexProps={{
                 disabled: true,
@@ -348,6 +350,7 @@ export default function FactionAdminApp(props: FactionAdminAppProps):JSX.Element
               fourthHexProps={{
                 icon: <TocIcon />,
                 link: '/factions',
+                tooltipText: "All Factions",
               }}
             />
           </Box>

--- a/components/factionProfileApp.tsx
+++ b/components/factionProfileApp.tsx
@@ -298,31 +298,37 @@ export default function FactionProfileApp(props: FactionProfileAppProps):JSX.Ele
                 icon: editMode ? <SaveIcon /> : <BorderColorIcon />,
                 disabled: !isAdmin,
                 handleAction: editButtonAction,
+                tooltipText: editMode ? "Save Changes" : "Edit Faction",
               }}
               secondHexProps={{
                 disabled: !isAdmin,
                 icon: <AllInboxIcon />,
                 link: `/factions/${accountId}/status/inbox`,
+                tooltipText: "Faction Statuses",
               }}
               bigHexProps={
                 isRep ? {
                   icon: <RateReviewIcon />,
                   link: `/factions/${accountId}/setstatus`,
+                  tooltipText: "Add Status As Faction",
                 } : {
                   icon: <RateReviewIcon />,
                   handleAction: writeButtonAction,
                   dialog: 'Share your thoughts with us?',
                   useInput: true,
+                  tooltipText: "Leave Message",
                 }
               }
               thirdHexProps={{
                 disabled: true,
                 icon: <TagIcon />,
                 link: `/factions/${accountId}/tags`,
+                tooltipText: "Faction Tags",
               }}
               fourthHexProps={{
                 icon: <TocIcon />,
                 link: '/factions',
+                tooltipText: "All Factions",
               }}
             />
           </Box>

--- a/components/factionSetStatusApp.tsx
+++ b/components/factionSetStatusApp.tsx
@@ -450,19 +450,22 @@ export default function FactionSetStatusApp(props: FactionSetStatusAppProps):JSX
               secondHexProps={{
                 icon: <QrCodeScannerIcon />,
                 disabled: true,
+                tooltipText: "Scan QR Code",
               }}
               bigHexProps={{
                 icon: <RateReviewIcon />,
                 handleAction: handleBigAction,
                 disabled: !isRep || loading,
                 loading: loading,
+                tooltipText: "Set Faction Status",
               }}
               thirdHexProps={{
                 disabled: true,
               }}
               fourthHexProps={{
                 icon: <SupervisedUserCircleIcon />,
-                link: `/factions/${accountId}`
+                link: `/factions/${accountId}`,
+                tooltipText: "Go To Faction",
               }}
             />
           </Box>

--- a/components/gardenApp.tsx
+++ b/components/gardenApp.tsx
@@ -212,26 +212,31 @@ export default function GardenApp(props: GardenAppProps): JSX.Element {
                 icon: filter ? <FilterListIcon /> : <FilterListOffIcon />,
                 handleAction: toggleFilter,
                 disabled: !isAdmin,
+                tooltipText: filter ? "See Only Public Statuses" : "See All Statuses",
               }}
               secondHexProps={{
                 icon: <AllInboxIcon />,
                 link: "/status/inbox",
+                tooltipText: "Inbox",
               }}
               bigHexProps={{
                 icon: <RateReviewIcon />,
                 handleAction: handleBigAction,
                 dialog: "What would you like to share?",
                 useInput: true,
+                tooltipText: "Post Status",
               }}
               thirdHexProps={{
                 icon: <BadgeIcon />,
                 link: `/contacts/${entity.id}`,
+                tooltipText: "Profile",
               }}
               fourthHexProps={{
                 icon: <PsychologyAltIcon />,
                 handleAction: handleLittleAction,
                 dialog: "Write a secret log entry for this user?",
                 useInput: true,
+                tooltipText: "Post Private Status",
               }}
             />
           </Box>

--- a/components/gardenSearchApp.tsx
+++ b/components/gardenSearchApp.tsx
@@ -152,6 +152,7 @@ export default function GardenSearchApp(
                 dialog: "Search for a User",
                 handleAction: searchForContact,
                 useInput: true,
+                tooltipText: "Search For User",
               }}
               thirdHexProps={{
                 disabled: true,
@@ -159,6 +160,7 @@ export default function GardenSearchApp(
               fourthHexProps={{
                 icon: <LocalFloristIcon />,
                 link: `/garden`,
+                tooltipText: "Jaden/Garden",
               }}
             />
           </Box>

--- a/components/statusAdminApp.tsx
+++ b/components/statusAdminApp.tsx
@@ -159,7 +159,8 @@ export default function StatusAdminApp(props: StatusAdminAppProps):JSX.Element {
               firstHexProps={{
                 icon: <NoMeetingRoomIcon />,
                 handleAction: goRemoveStatus,
-                dialog: "Delete this status?"
+                dialog: "Delete this status?",
+                tooltipText: "Delete Status",
               }}
               secondHexProps={{
                 disabled: true,
@@ -168,6 +169,7 @@ export default function StatusAdminApp(props: StatusAdminAppProps):JSX.Element {
                 icon: selectedStatus && selectedStatus.class === 'public' ? <VisibilityIcon /> : <VisibilityOffIcon />,
                 handleAction: goToggleStatus,
                 disabled: alertShow,
+                tooltipText: selectedStatus && selectedStatus.class === 'public' ? "Make Status Private" : "Make Status Public",
               }}
               thirdHexProps={{
                 disabled: true,
@@ -175,6 +177,7 @@ export default function StatusAdminApp(props: StatusAdminAppProps):JSX.Element {
               fourthHexProps={{
                 icon: <TocIcon />,
                 link: factionId ? `/factions/${factionId}` : '/garden',
+                tooltipText: factionId ? "Faction" : "Jaden/Garden",
               }}
             />
           </Box>

--- a/components/statusesApp.tsx
+++ b/components/statusesApp.tsx
@@ -185,10 +185,12 @@ export default function GardenApp(props: GardenAppProps):JSX.Element {
               thirdHexProps={{
                 icon: outbound ? <OutboxIcon /> : <MoveToInboxIcon />,
                 link: boxLink(),
+                tooltipText: outbound ? "Outbox" : "Inbox",
               }}
               fourthHexProps={{
                 icon: <ListIcon />,
-                link: factionId ? `/factions/${factionId}` : '/garden'
+                link: factionId ? `/factions/${factionId}` : '/garden',
+                tooltipText: factionId ? "Faction" : "Jaden/Garden",
               }}
             />
           </Box>

--- a/components/userProfileApp.tsx
+++ b/components/userProfileApp.tsx
@@ -273,6 +273,7 @@ export default function UserProfileApp(props: UserProfileAppProps):JSX.Element {
                 icon: editMode ? <SaveIcon /> : <BorderColorIcon />,
                 disabled: isAdmin,
                 handleAction: bigButtonAction,
+                tooltipText: editMode ? "Save Profile" : "Edit Profile",
               }}
             />
           </Box>


### PR DESCRIPTION
## What
Add tooltips to all hexagon footer buttons that work on hover for desktop and on press and hold for mobile usage.

## Why
Across NeoNav the hexagon footer navigation uses icon with no text description; the lack of description and limitations of icons makes some interactions unintuitive without user experimentation leading to a poor user experience. This PR aims to add tooltips to each footer so that users can see what a button will do without the need to actually click the button, hopefully reducing confusion and increase user experience.